### PR TITLE
Add +Movment tool and save-as workflow

### DIFF
--- a/json_merger.py
+++ b/json_merger.py
@@ -284,6 +284,26 @@ class JSONMergerLogic:
         walk(self.json2)
         return sorted(ids)
 
+    def storeid_name_map(self, project: int = 2) -> dict[int, str]:
+        data = self.json2 if project == 2 else self.json1
+        mapping: dict[int, str] = {}
+
+        def walk(node: Any) -> None:
+            if isinstance(node, dict):
+                sid = node.get("storeID")
+                if isinstance(sid, int):
+                    name = node.get("name") or node.get("id")
+                    if isinstance(name, str) and sid not in mapping:
+                        mapping[sid] = name
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(data)
+        return mapping
+
     def _read_config_from_archive(self, path: str) -> str:
         with zipfile.ZipFile(path, "r") as archive:
             names = [n for n in archive.namelist() if n.lower().endswith("config.json")]

--- a/json_merger.py
+++ b/json_merger.py
@@ -355,7 +355,7 @@ class JSONMergerLogic:
             for face_name, coords in element["faceUV"].items():
                 if not isinstance(coords, dict):
                     continue
-                if face_name.lower() in {"up", "down"}:
+                if face_name.lower() in {"up"}:
                     continue
                 for key in ("sx", "ex", "sy", "ey"):
                     if key in coords and isinstance(coords[key], (int, float)):
@@ -364,6 +364,11 @@ class JSONMergerLogic:
                             coords[key] += 6 * (2 if skin_x128 else 1)
                 coords.setdefault("rot", "0")
                 coords.setdefault("autoUV", True)
+            if "down" in element["faceUV"]:
+                coords = element["faceUV"]["down"]
+                if isinstance(coords, dict):
+                    coords.setdefault("rot", "0")
+                    coords.setdefault("autoUV", True)
             if base_uv:
                 element.setdefault("u", base_uv[0])
                 element.setdefault("v", base_uv[1])
@@ -386,12 +391,19 @@ class JSONMergerLogic:
             "south": {"sx": u + z + x, "sy": v + z, "ex": u + z + x + x, "ey": v + z + y},
             "north": {"sx": u + z, "sy": v + z, "ex": u + z + x, "ey": v + z + y},
             "west": {"sx": u + z + x + x, "sy": v + z, "ex": u + z + x + x + z, "ey": v + z + y},
+            "down": {"sx": u + x + z, "sy": v, "ex": u + x + z + x, "ey": v + z},
         }
         for coords in face_uv.values():
             coords["sy"] += 6 * scale
             coords["ey"] += 6 * scale
             coords["rot"] = "0"
             coords["autoUV"] = True
+        # Remove face down para mangas (sleeves) e calças (pants) originais
+        name_val = element.get("name") or element.get("id") or ""
+        if isinstance(name_val, str):
+            lowered = name_val.lower()
+            if ("sleeve" in lowered or "pants" in lowered) and "down" in face_uv:
+                face_uv.pop("down", None)
         element["faceUV"] = face_uv
         element["u"] = u
         element["v"] = v

--- a/json_merger.py
+++ b/json_merger.py
@@ -261,7 +261,38 @@ class JSONMergerLogic:
         if not isinstance(children, list):
             children = []
             element["children"] = children
+        JSONMergerLogic._reorder_children_key(element)
         return children
+
+    @staticmethod
+    def _reorder_children_key(element: dict[str, Any]) -> None:
+        if "children" not in element or not isinstance(element, dict):
+            return
+        children_value = element.pop("children")
+        inserted = False
+        # Tenta após DisableVanillaAnim
+        if "DisableVanillaAnim" in element:
+            new_data: dict[str, Any] = {}
+            for key, value in element.items():
+                new_data[key] = value
+                if key == "DisableVanillaAnim":
+                    new_data["children"] = children_value
+                    inserted = True
+            element.clear()
+            element.update(new_data)
+        # Se não inseriu, tenta antes de pos
+        if not inserted and "pos" in element:
+            new_data = {}
+            for key, value in element.items():
+                if key == "pos":
+                    new_data["children"] = children_value
+                    inserted = True
+                new_data[key] = value
+            element.clear()
+            element.update(new_data)
+        # Caso nada se aplique, reinsere no final (comportamento anterior)
+        if not inserted:
+            element["children"] = children_value
 
     def _build_hierarchy(
         self,

--- a/json_merger.py
+++ b/json_merger.py
@@ -280,11 +280,11 @@ class JSONMergerLogic:
                     inserted = True
             element.clear()
             element.update(new_data)
-        # Se não inseriu, tenta antes de pos
-        if not inserted and "pos" in element:
+        # Se não inseriu, tenta antes de v
+        if not inserted and "v" in element:
             new_data = {}
             for key, value in element.items():
-                if key == "pos":
+                if key == "v":
                     new_data["children"] = children_value
                     inserted = True
                 new_data[key] = value

--- a/json_merger.py
+++ b/json_merger.py
@@ -349,6 +349,7 @@ class JSONMergerLogic:
             return
         tex_scale_raw = element.get("texScale", 1)
         tex_scale: float = tex_scale_raw if isinstance(tex_scale_raw, (int, float)) else 1
+        base_uv = self._extract_uv(element)
         if "faceUV" in element and isinstance(element["faceUV"], dict):
             for face_name, coords in element["faceUV"].items():
                 if not isinstance(coords, dict):
@@ -360,8 +361,10 @@ class JSONMergerLogic:
                         coords[key] += 6
                 coords.setdefault("rot", "0")
                 coords.setdefault("autoUV", True)
+            if base_uv:
+                element.setdefault("u", base_uv[0])
+                element.setdefault("v", base_uv[1])
             return
-        base_uv = self._extract_uv(element)
         size = self._extract_size(element)
         if base_uv is None or size is None:
             return
@@ -381,9 +384,8 @@ class JSONMergerLogic:
             coords["rot"] = "0"
             coords["autoUV"] = True
         element["faceUV"] = face_uv
-        element.pop("uv", None)
-        element.pop("u", None)
-        element.pop("v", None)
+        element["u"] = u
+        element["v"] = v
 
     @staticmethod
     def _extract_uv(element: dict[str, Any]) -> tuple[float, float] | None:

--- a/json_merger.py
+++ b/json_merger.py
@@ -38,6 +38,17 @@ class JSONMergerLogic:
                 else:
                     archive.writestr(name, data)
 
+    def save_project2_as(self, path: str) -> None:
+        if not self.project2_archive:
+            raise ValueError("Carregue o Projeto 2 antes de salvar")
+        with zipfile.ZipFile(path, "w") as archive:
+            for name, data in self.project2_archive.items():
+                if name.lower().endswith("config.json"):
+                    archive.writestr(name, json.dumps(self.json2, indent=2, ensure_ascii=False))
+                else:
+                    archive.writestr(name, data)
+        self.project2_path = path
+
     def clear_clipboard(self) -> None:
         self.clipboard = None
         self.clipboard_mode = None
@@ -110,6 +121,99 @@ class JSONMergerLogic:
                 pass
         self.clear_clipboard()
 
+    def list_elements(self) -> list[tuple[str, List[int | str]]]:
+        results: list[tuple[str, List[int | str]]] = []
+
+        def walk(node: Any, path: List[int | str]) -> None:
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    if key in {"elements", "children"} and isinstance(value, list):
+                        for idx, element in enumerate(value):
+                            if isinstance(element, dict):
+                                label = element.get("id") or element.get("name") or f"{key}[{idx}]"
+                                results.append((str(label), path + [key, idx]))
+                                walk(element, path + [key, idx])
+                    else:
+                        walk(value, path + [key])
+            elif isinstance(node, list):
+                for idx, item in enumerate(node):
+                    walk(item, path + [idx])
+
+        walk(self.json2, [])
+        return results
+
+    def apply_movement_tool(self, selection: dict[str, List[int | str]]) -> None:
+        if not self.project2_archive:
+            raise ValueError("Carregue o Projeto 2 antes de aplicar o +Movment")
+        required_keys = {
+            "left_arm",
+            "right_arm",
+            "left_leg",
+            "right_leg",
+            "left_sleeve",
+            "right_sleeve",
+            "left_pants",
+            "right_pants",
+        }
+        if set(selection) != required_keys:
+            raise ValueError("Seleção incompleta para +Movment")
+        refs = {key: self._element_ref(path) for key, path in selection.items()}
+        anti_refs: dict[str, dict[str, Any]] = {}
+        for key, ref in refs.items():
+            clone = copy.deepcopy(ref["obj"])
+            self._prefix_element_name(clone, "Anti_")
+            ref["parent_list"].append(clone)
+            anti_refs[key] = {"obj": clone, "parent_list": ref["parent_list"]}
+        for key in required_keys:
+            self._set_y_size(refs[key]["obj"], 7)
+        for anti in anti_refs.values():
+            self._set_y_size(anti["obj"], 6)
+        for key in ("left_arm", "right_arm", "left_leg", "right_leg"):
+            self._set_y_position(anti_refs[key]["obj"], 6)
+        self._build_hierarchy(
+            parent_ref=refs["left_arm"],
+            child_refs=[
+                anti_refs["left_arm"],
+                refs["left_sleeve"],
+            ],
+            anti_child_ref=anti_refs["left_sleeve"],
+        )
+        self._build_hierarchy(
+            parent_ref=refs["right_arm"],
+            child_refs=[
+                anti_refs["right_arm"],
+                refs["right_sleeve"],
+            ],
+            anti_child_ref=anti_refs["right_sleeve"],
+        )
+        self._build_hierarchy(
+            parent_ref=refs["left_leg"],
+            child_refs=[
+                anti_refs["left_leg"],
+                refs["left_pants"],
+            ],
+            anti_child_ref=anti_refs["left_pants"],
+        )
+        self._build_hierarchy(
+            parent_ref=refs["right_leg"],
+            child_refs=[
+                anti_refs["right_leg"],
+                refs["right_pants"],
+            ],
+            anti_child_ref=anti_refs["right_pants"],
+        )
+        for key in (
+            "left_arm",
+            "right_arm",
+            "left_leg",
+            "right_leg",
+            "left_sleeve",
+            "right_sleeve",
+            "left_pants",
+            "right_pants",
+        ):
+            self._apply_per_face_uv(anti_refs[key]["obj"])
+
     def _read_config_from_archive(self, path: str) -> str:
         with zipfile.ZipFile(path, "r") as archive:
             names = [n for n in archive.namelist() if n.lower().endswith("config.json")]
@@ -124,3 +228,146 @@ class JSONMergerLogic:
             return raw.decode("utf-8")
         except UnicodeDecodeError:
             return raw.decode("latin-1")
+
+    def _element_ref(self, path: List[int | str]) -> dict[str, Any]:
+        parent = self.get_by_path(self.json2, path[:-1])
+        if not isinstance(parent, list):
+            raise ValueError("Elemento selecionado não está dentro de uma lista")
+        return {
+            "obj": self.get_by_path(self.json2, path),
+            "parent_list": parent,
+        }
+
+    @staticmethod
+    def _prefix_element_name(element: Any, prefix: str) -> None:
+        if not isinstance(element, dict):
+            return
+        if "name" in element and isinstance(element["name"], str):
+            element["name"] = f"{prefix}{element['name']}"
+        elif "id" in element and isinstance(element["id"], str):
+            element["id"] = f"{prefix}{element['id']}"
+
+    @staticmethod
+    def _ensure_children(element: dict[str, Any]) -> list:
+        children = element.get("children")
+        if not isinstance(children, list):
+            children = []
+            element["children"] = children
+        return children
+
+    def _build_hierarchy(
+        self,
+        parent_ref: dict[str, Any],
+        child_refs: list[dict[str, Any]],
+        anti_child_ref: dict[str, Any],
+    ) -> None:
+        parent_obj = parent_ref["obj"]
+        parent_children = self._ensure_children(parent_obj)
+        for child in child_refs:
+            self._move_to_children(parent_children, child)
+        anti_parent_children = self._ensure_children(child_refs[0]["obj"])
+        self._move_to_children(anti_parent_children, anti_child_ref)
+
+    def _move_to_children(self, target_children: list, child_ref: dict[str, Any]) -> None:
+        child_obj = child_ref["obj"]
+        parent_list = child_ref["parent_list"]
+        try:
+            if parent_list is not target_children and child_obj in parent_list:
+                parent_list.remove(child_obj)
+        except ValueError:
+            pass
+        if child_obj not in target_children:
+            target_children.append(child_obj)
+        child_ref["parent_list"] = target_children
+
+    @staticmethod
+    def _set_y_size(element: Any, value: int | float) -> None:
+        if not isinstance(element, dict):
+            return
+        size = element.get("size")
+        if isinstance(size, list) and len(size) >= 2:
+            size[1] = value
+        elif isinstance(size, dict):
+            for key in ("y", "Y", "height"):
+                if key in size:
+                    size[key] = value
+
+    @staticmethod
+    def _set_y_position(element: Any, value: int | float) -> None:
+        if not isinstance(element, dict):
+            return
+        for key in ("pos", "position", "origin", "translate", "pivot"):
+            pos = element.get(key)
+            if isinstance(pos, list) and len(pos) >= 2:
+                pos[1] = value
+            elif isinstance(pos, dict):
+                for axis_key in ("y", "Y"):
+                    if axis_key in pos:
+                        pos[axis_key] = value
+
+    def _apply_per_face_uv(self, element: Any) -> None:
+        if not isinstance(element, dict):
+            return
+        tex_scale_raw = element.get("texScale", 1)
+        tex_scale: float = tex_scale_raw if isinstance(tex_scale_raw, (int, float)) else 1
+        if "faceUV" in element and isinstance(element["faceUV"], dict):
+            for face_name, coords in element["faceUV"].items():
+                if not isinstance(coords, dict):
+                    continue
+                if face_name.lower() in {"up", "down"}:
+                    continue
+                for key in ("sy", "ey"):
+                    if key in coords and isinstance(coords[key], (int, float)):
+                        coords[key] += 6
+            return
+        base_uv = self._extract_uv(element)
+        size = self._extract_size(element)
+        if base_uv is None or size is None:
+            return
+        u, v = base_uv
+        x, y, z = (component * tex_scale for component in size)
+        u *= tex_scale
+        v *= tex_scale
+        face_uv = {
+            "north": {"sx": u + z, "sy": v + z, "ex": u + z + x, "ey": v + z + y},
+            "east": {"sx": u, "sy": v + z, "ex": u + z, "ey": v + z + y},
+            "south": {"sx": u + z + x, "sy": v + z, "ex": u + z + x + x, "ey": v + z + y},
+            "west": {"sx": u + z + x + x, "sy": v + z, "ex": u + z + x + x + z, "ey": v + z + y},
+            "up": {"sx": u + z, "sy": v, "ex": u + z + x, "ey": v + z},
+            "down": {"sx": u + x + z, "sy": v, "ex": u + x + z + x, "ey": v + z},
+        }
+        for name, coords in face_uv.items():
+            if name in {"up", "down"}:
+                continue
+            coords["sy"] += 6
+            coords["ey"] += 6
+        element["faceUV"] = face_uv
+        element.pop("uv", None)
+        element.pop("u", None)
+        element.pop("v", None)
+
+    @staticmethod
+    def _extract_uv(element: dict[str, Any]) -> tuple[float, float] | None:
+        if "uv" in element:
+            uv = element["uv"]
+            if isinstance(uv, list) and len(uv) >= 2:
+                return float(uv[0]), float(uv[1])
+        if "u" in element and "v" in element:
+            u = element["u"]
+            v = element["v"]
+            if isinstance(u, (int, float)) and isinstance(v, (int, float)):
+                return float(u), float(v)
+        return None
+
+    @staticmethod
+    def _extract_size(element: dict[str, Any]) -> tuple[float, float, float] | None:
+        size = element.get("size")
+        if isinstance(size, list) and len(size) >= 3:
+            return float(size[0]), float(size[1]), float(size[2])
+        if isinstance(size, dict):
+            x = size.get("x") if "x" in size else size.get("X")
+            y = size.get("y") if "y" in size else size.get("Y")
+            z = size.get("z") if "z" in size else size.get("Z")
+            if isinstance(x, (int, float)) and isinstance(y, (int, float)) and isinstance(z, (int, float)):
+                return float(x), float(y), float(z)
+        return None

--- a/json_merger.py
+++ b/json_merger.py
@@ -358,6 +358,8 @@ class JSONMergerLogic:
                 for key in ("sy", "ey"):
                     if key in coords and isinstance(coords[key], (int, float)):
                         coords[key] += 6
+                coords.setdefault("rot", "0")
+                coords.setdefault("autoUV", True)
             return
         base_uv = self._extract_uv(element)
         size = self._extract_size(element)
@@ -368,18 +370,16 @@ class JSONMergerLogic:
         u *= tex_scale
         v *= tex_scale
         face_uv = {
-            "north": {"sx": u + z, "sy": v + z, "ex": u + z + x, "ey": v + z + y},
             "east": {"sx": u, "sy": v + z, "ex": u + z, "ey": v + z + y},
             "south": {"sx": u + z + x, "sy": v + z, "ex": u + z + x + x, "ey": v + z + y},
+            "north": {"sx": u + z, "sy": v + z, "ex": u + z + x, "ey": v + z + y},
             "west": {"sx": u + z + x + x, "sy": v + z, "ex": u + z + x + x + z, "ey": v + z + y},
-            "up": {"sx": u + z, "sy": v, "ex": u + z + x, "ey": v + z},
-            "down": {"sx": u + x + z, "sy": v, "ex": u + x + z + x, "ey": v + z},
         }
-        for name, coords in face_uv.items():
-            if name in {"up", "down"}:
-                continue
+        for coords in face_uv.values():
             coords["sy"] += 6
             coords["ey"] += 6
+            coords["rot"] = "0"
+            coords["autoUV"] = True
         element["faceUV"] = face_uv
         element.pop("uv", None)
         element.pop("u", None)

--- a/json_merger.py
+++ b/json_merger.py
@@ -375,15 +375,14 @@ class JSONMergerLogic:
             t = step / (insert_count + 1)
             comps: list[dict[str, Any]] = []
             for sid in union_ids:
-                src = start_map.get(sid) or end_map.get(sid)
-                dst = end_map.get(sid) or start_map.get(sid)
+                src = start_map.get(sid) or {}
+                dst = end_map.get(sid) or {}
                 if not isinstance(src, dict) or not isinstance(dst, dict):
                     continue
-                comp = copy.deepcopy(src)
-                if "pos" in src and "pos" in dst:
-                    comp["pos"] = self._lerp_vectors(src.get("pos"), dst.get("pos"), t)
-                if "rotation" in src and "rotation" in dst:
-                    comp["rotation"] = self._lerp_vectors(src.get("rotation"), dst.get("rotation"), t)
+                comp = copy.deepcopy(src if src else dst)
+                comp["storeID"] = sid
+                comp["pos"] = self._lerp_vectors(src.get("pos"), dst.get("pos"), t)
+                comp["rotation"] = self._lerp_vectors(src.get("rotation"), dst.get("rotation"), t)
                 comps.append(comp)
             new_frames.append({"components": comps})
 

--- a/main_window.py
+++ b/main_window.py
@@ -223,6 +223,13 @@ class JSONMergerWindow(QtWidgets.QMainWindow):
         self.search_index = 0
         self.last_search_scope = None
 
+    def _toggle_elements_only(self) -> None:
+        self.show_only_elements = self.elements_only_checkbox.isChecked()
+        if self.logic.json1:
+            self._build_tree(self.tree1, self.logic.json1)
+        if self.logic.json2:
+            self._build_tree(self.tree2, self.logic.json2)
+
     def _build_tree(self, tree: QtWidgets.QTreeWidget, data: object) -> None:
         tree.clear()
         root = QtWidgets.QTreeWidgetItem(["root"])
@@ -574,13 +581,6 @@ class MovementDialog(QtWidgets.QDialog):
         elif isinstance(value, list):
             for idx, element in enumerate(value):
                 self._insert_elements_only(tree, parent, element, path + [idx])
-
-    def _toggle_elements_only(self) -> None:
-        self.show_only_elements = self.elements_only_checkbox.isChecked()
-        if self.logic.json1:
-            self._build_tree(self.tree1, self.logic.json1)
-        if self.logic.json2:
-            self._build_tree(self.tree2, self.logic.json2)
 
 
 def run_app() -> None:

--- a/main_window.py
+++ b/main_window.py
@@ -279,6 +279,33 @@ class JSONMergerWindow(QtWidgets.QMainWindow):
             item.setForeground(0, QtGui.QBrush(QtGui.QColor("#5c5c5c")))
             parent.addChild(item)
 
+    def _insert_elements_only(
+        self,
+        tree: QtWidgets.QTreeWidget,
+        parent: QtWidgets.QTreeWidgetItem,
+        value: object,
+        path: List[int | str],
+    ) -> None:
+        if isinstance(value, dict):
+            for key in ("children", "elements"):
+                val = value.get(key)
+                if isinstance(val, list):
+                    for idx, element in enumerate(val):
+                        if not isinstance(element, dict):
+                            continue
+                        label = element.get("id") or element.get("name") or f"[{idx}]"
+                        item = QtWidgets.QTreeWidgetItem([label])
+                        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, path + [key, idx])
+                        item.setForeground(0, QtGui.QBrush(QtGui.QColor("#1b7fb3")))
+                        font = item.font(0)
+                        font.setBold(True)
+                        item.setFont(0, font)
+                        parent.addChild(item)
+                        self._insert_elements_only(tree, item, element, path + [key, idx])
+        elif isinstance(value, list):
+            for idx, element in enumerate(value):
+                self._insert_elements_only(tree, parent, element, path + [idx])
+
     def _highlight(self, tree: QtWidgets.QTreeWidget, item: QtWidgets.QTreeWidgetItem) -> None:
         ancestor = item.parent()
         while ancestor:
@@ -554,34 +581,6 @@ class MovementDialog(QtWidgets.QDialog):
                 if text == target:
                     combo.setCurrentIndex(index)
                     break
-
-    def _insert_elements_only(
-        self,
-        tree: QtWidgets.QTreeWidget,
-        parent: QtWidgets.QTreeWidgetItem,
-        value: object,
-        path: List[int | str],
-    ) -> None:
-        if isinstance(value, dict):
-            for key in ("children", "elements"):
-                val = value.get(key)
-                if isinstance(val, list):
-                    for idx, element in enumerate(val):
-                        if not isinstance(element, dict):
-                            continue
-                        label = element.get("id") or element.get("name") or f"[{idx}]"
-                        item = QtWidgets.QTreeWidgetItem([label])
-                        item.setData(0, QtCore.Qt.ItemDataRole.UserRole, path + [key, idx])
-                        item.setForeground(0, QtGui.QBrush(QtGui.QColor("#1b7fb3")))
-                        font = item.font(0)
-                        font.setBold(True)
-                        item.setFont(0, font)
-                        parent.addChild(item)
-                        self._insert_elements_only(tree, item, element, path + [key, idx])
-        elif isinstance(value, list):
-            for idx, element in enumerate(value):
-                self._insert_elements_only(tree, parent, element, path + [idx])
-
 
 def run_app() -> None:
     app = QtWidgets.QApplication(sys.argv)

--- a/main_window.py
+++ b/main_window.py
@@ -32,7 +32,7 @@ class JSONMergerWindow(QtWidgets.QMainWindow, StatusMixin):
         self.search_results: list[QtWidgets.QTreeWidgetItem] = []
         self.search_index = 0
         self.last_search_scope: str | None = None
-        self.show_only_elements = False
+        self.show_only_elements = True
         self._setup_ui()
         self.statusBar().showMessage("Pronto")
 
@@ -62,6 +62,14 @@ class JSONMergerWindow(QtWidgets.QMainWindow, StatusMixin):
         self.btn_save_as.clicked.connect(self.save_project2_as)
         top_button_row.addWidget(self.btn_save_as)
 
+        self.btn_options = QtWidgets.QPushButton("Opções")
+        self.options_menu = QtWidgets.QMenu(self)
+        self.dark_mode_action = self.options_menu.addAction("Modo escuro")
+        self.dark_mode_action.setCheckable(True)
+        self.dark_mode_action.toggled.connect(self._toggle_dark_mode)
+        self.btn_options.setMenu(self.options_menu)
+        top_button_row.addWidget(self.btn_options)
+
         self.tabs = QtWidgets.QTabWidget()
         layout.addWidget(self.tabs, 1)
 
@@ -82,6 +90,7 @@ class JSONMergerWindow(QtWidgets.QMainWindow, StatusMixin):
         tools_row.addWidget(self._create_tool_button("🎨", "Colorir hierarquia", self.colorize_hierarchy))
 
         self.elements_only_checkbox = QtWidgets.QCheckBox("apenas Elementos")
+        self.elements_only_checkbox.setChecked(True)
         self.elements_only_checkbox.stateChanged.connect(self._toggle_elements_only)
         models_layout.addWidget(self.elements_only_checkbox)
 
@@ -299,6 +308,28 @@ class JSONMergerWindow(QtWidgets.QMainWindow, StatusMixin):
             self._build_tree(self.tree1, self.logic.json1)
         if self.logic.json2:
             self._build_tree(self.tree2, self.logic.json2)
+
+    def _toggle_dark_mode(self, enabled: bool) -> None:
+        app = QtWidgets.QApplication.instance()
+        if not app:
+            return
+        if enabled:
+            palette = QtGui.QPalette()
+            palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor(53, 53, 53))
+            palette.setColor(QtGui.QPalette.ColorRole.WindowText, QtGui.QColor(220, 220, 220))
+            palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(35, 35, 35))
+            palette.setColor(QtGui.QPalette.ColorRole.AlternateBase, QtGui.QColor(53, 53, 53))
+            palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, QtGui.QColor(220, 220, 220))
+            palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, QtGui.QColor(220, 220, 220))
+            palette.setColor(QtGui.QPalette.ColorRole.Text, QtGui.QColor(220, 220, 220))
+            palette.setColor(QtGui.QPalette.ColorRole.Button, QtGui.QColor(53, 53, 53))
+            palette.setColor(QtGui.QPalette.ColorRole.ButtonText, QtGui.QColor(220, 220, 220))
+            palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtGui.QColor(255, 0, 0))
+            palette.setColor(QtGui.QPalette.ColorRole.Highlight, QtGui.QColor(142, 45, 197).lighter())
+            palette.setColor(QtGui.QPalette.ColorRole.HighlightedText, QtGui.QColor(0, 0, 0))
+            app.setPalette(palette)
+        else:
+            app.setPalette(app.style().standardPalette())
 
     def _build_tree(self, tree: QtWidgets.QTreeWidget, data: object) -> None:
         tree.clear()

--- a/main_window.py
+++ b/main_window.py
@@ -690,17 +690,25 @@ class AnimationMappingDialog(QtWidgets.QDialog):
             return
         source_ids = self.logic.extract_store_ids(self.logic.animation_clipboard)
         target_ids = self.logic.extract_store_ids_from_model()
+        source_names = self.logic.storeid_name_map(project=1)
+        target_names = self.logic.storeid_name_map(project=2)
 
-        form = QtWidgets.QFormLayout()
+        grid = QtWidgets.QGridLayout()
         self.combos: dict[int, QtWidgets.QComboBox] = {}
-        for sid in source_ids:
+        rows_per_col = 8
+        for idx, sid in enumerate(source_ids):
             combo = QtWidgets.QComboBox()
             combo.addItem(f"Manter ({sid})", userData=sid)
             for tid in target_ids:
-                combo.addItem(str(tid), userData=tid)
-            form.addRow(f"storeID {sid}", combo)
+                text = target_names.get(tid, str(tid))
+                combo.addItem(f"{text} ({tid})", userData=tid)
+            row = idx % rows_per_col
+            col = idx // rows_per_col
+            label_text = source_names.get(sid, f"storeID {sid}")
+            grid.addWidget(QtWidgets.QLabel(label_text), row, col * 2)
+            grid.addWidget(combo, row, col * 2 + 1)
             self.combos[sid] = combo
-        layout.addLayout(form)
+        layout.addLayout(grid)
 
         buttons = QtWidgets.QHBoxLayout()
         btn_ok = QtWidgets.QPushButton("OK")

--- a/main_window.py
+++ b/main_window.py
@@ -511,6 +511,9 @@ class MovementDialog(QtWidgets.QDialog):
         self.debug_checkbox = QtWidgets.QCheckBox("DEBUG (salvar cada etapa)")
         layout.addWidget(self.debug_checkbox)
 
+        self.skin_checkbox = QtWidgets.QCheckBox("skin x128")
+        layout.addWidget(self.skin_checkbox)
+
         buttons = QtWidgets.QHBoxLayout()
         apply_btn = QtWidgets.QPushButton("Aplicar")
         apply_btn.clicked.connect(self._run_tool)
@@ -536,7 +539,8 @@ class MovementDialog(QtWidgets.QDialog):
             return
         try:
             debug_hook = self._build_debug_hook() if self.debug_checkbox.isChecked() else None
-            self.logic.apply_movement_tool(selection, debug_hook=debug_hook)
+            skin_x128 = self.skin_checkbox.isChecked()
+            self.logic.apply_movement_tool(selection, debug_hook=debug_hook, skin_x128=skin_x128)
             QtWidgets.QMessageBox.information(self, "OBaaaaa", "Deu bom :)")
             self.accept()
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- add a Save As option so Projeto 2 can be gravado em um novo caminho com a extensão correta
- aplicar cores aos itens da árvore para diferenciar elementos e atributos e exibir um novo atalho +Movment
- implementar a ferramenta +Movment: seleção de membros, duplicação com prefixo Anti_, hierarquias, ajustes de tamanho/posição e UV Per-Face

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b2f1db388328a03e4df30e72c138)